### PR TITLE
Missing single quote

### DIFF
--- a/docs/functions/not.md
+++ b/docs/functions/not.md
@@ -24,6 +24,6 @@ $notAnArray(123456);
 // => true
 
 
-$notAnArray(['this is' => 'an array]);            
+$notAnArray(['this is' => 'an array']);            
 // => false
 ```


### PR DESCRIPTION
A missing quote in the not() function example has been added