### PR TITLE
Transform collection only to array when necessary

### DIFF
--- a/src/map.php
+++ b/src/map.php
@@ -21,7 +21,7 @@ use ArgumentCountError;
 function map(callable $fn, iterable $coll): array
 {
     try {
-        return ___map_indexed($fn, $args);
+        return ___map_indexed($fn, $coll);
     } catch (ArgumentCountError $error) {
         return array_map($fn, to_array($coll));
     }

--- a/src/map.php
+++ b/src/map.php
@@ -20,12 +20,10 @@ use ArgumentCountError;
  */
 function map(callable $fn, iterable $coll): array
 {
-    $args = to_array($coll);
-
     try {
         return ___map_indexed($fn, $args);
     } catch (ArgumentCountError $error) {
-        return array_map($fn, $args);
+        return array_map($fn, to_array($coll));
     }
 }
 


### PR DESCRIPTION
`___map_indexed` can handle an `iterable`, so there is no need to transform it into an array first.